### PR TITLE
Add max level of 20

### DIFF
--- a/Assets/Scripts/Common/Controller/BattleStates/SkirmishStates/AwardExpState.cs
+++ b/Assets/Scripts/Common/Controller/BattleStates/SkirmishStates/AwardExpState.cs
@@ -10,11 +10,12 @@ public class AwardExpState : BattleState
         base.Enable();
         this.AddObserver(OnAwardExpFinished, NotificationBook.AWARD_EXP_FINISHED); 
 
-        Init();
+        StartCoroutine(Init());
     }
 
-    private void Init()
+    private IEnumerator Init()
     {
+        yield return null;
         Skirmish skirmish = skirmishController.GetSkirmish();
         Unit expRecipient;
         Unit otherUnit;
@@ -28,12 +29,19 @@ public class AwardExpState : BattleState
             expRecipient = skirmish.initiator;
             otherUnit = skirmish.receiver;
         }
-        
-        this.PostNotification(NotificationBook.AWARD_EXP_INIT, expRecipient);
-        //tell levelComponent & modify stats on the actual unit
-        int exp = ExperienceManager.AwardExp(skirmish, expRecipient, otherUnit);
 
-        this.PostNotification(NotificationBook.AWARD_EXP_START, exp);
+        // max level of 20       
+        if (expRecipient.levelComponent.LVL == 20)
+        {
+            owner.ChangeState<FinishSkirmishState>();
+        }
+        else
+        {
+            this.PostNotification(NotificationBook.AWARD_EXP_INIT, expRecipient);
+            //tell levelComponent & modify stats on the actual unit
+            int exp = ExperienceManager.AwardExp(skirmish, expRecipient, otherUnit);
+            this.PostNotification(NotificationBook.AWARD_EXP_START, exp);
+        }
     }
 
     private void OnAwardExpFinished(object sender, object n_u)

--- a/Assets/Scripts/Common/Controller/ExperienceManager.cs
+++ b/Assets/Scripts/Common/Controller/ExperienceManager.cs
@@ -54,6 +54,7 @@ public static class ExperienceManager
   public static int AwardExp(Skirmish skirmish, Unit player, Unit opponent)
   {
     if (skirmish == null) { throw new System.Exception("Tried to award exp, but there was no skirmish available in the ExperienceManager."); }
+    if (player.levelComponent.LVL == 20) { return 0; }
     //only implemented weapon attack so far.
     int exp = 1;
 

--- a/Assets/Scripts/Common/UI/SkirmishPlayView/LevelUpPane.cs
+++ b/Assets/Scripts/Common/UI/SkirmishPlayView/LevelUpPane.cs
@@ -100,6 +100,9 @@ public class LevelUpPane : MonoBehaviour
 
     public IEnumerator PlayLevelUp()
     {
+        IterateStatBy(lvlText, 1);
+        yield return new WaitForSeconds(0.75f);
+        lvlText.color = Color.white;
         foreach(var key in textReference.Keys)
         {
             if (levelPackage[key] == 0) { continue; }

--- a/Assets/Scripts/Unit/UnitFactory.cs
+++ b/Assets/Scripts/Unit/UnitFactory.cs
@@ -24,6 +24,7 @@ public class UnitFactory : MonoBehaviour
         unit.unitStats = unit.GetComponentInChildren<UnitStats>();
 
         unit.unitStats.LoadStats();
+        
         unit.HP = unit.stats[StatTypes.MHP];
 
         unit.spriteRenderer = unit.GetComponent<SpriteRenderer>();

--- a/Assets/Scripts/View Model Component/Actor/LevelComponent.cs
+++ b/Assets/Scripts/View Model Component/Actor/LevelComponent.cs
@@ -68,10 +68,11 @@ public class LevelComponent : MonoBehaviour
   }
   #endregion
   #region Public
-  public void Init (int level, int experience)
+  public void Init (int level, int experience, int rank)
   {
     stats.SetValue(StatTypes.LVL, level, false);
     stats.SetValue(StatTypes.EXP, experience, false);
+    stats.SetValue(StatTypes.RNK, rank, false);
   }
 
   public void LoadLevelComponent(int exp, int level, int rank)

--- a/Assets/Scripts/View Model Component/Actor/UnitStats.cs
+++ b/Assets/Scripts/View Model Component/Actor/UnitStats.cs
@@ -30,8 +30,8 @@ public class UnitStats : MonoBehaviour
     public Stats stats;
 
     //fields just for loading unit xp and lvl from the unit data into the level component, not meant to be used outside the unit factory
-    int LOAD_XP;
-    int LOAD_LVL;
+    [SerializeField]int LOAD_XP;
+    [SerializeField]int LOAD_LVL;
     #endregion
 
     #region Monobehaviour


### PR DESCRIPTION
- adjust ExperienceManager and LevelComponent to have a max level of 20
- adjust AwardExpState and ExperienceViewController to handle units of level 20 (no exp)
- adjust AwardExpState and ExperienceViewController to handle units that level up to 20 (level up, then ignore remaining exp)
- fix LevelUpPane to change lvlText when playing a level up